### PR TITLE
Added support for 301 redirects; fixed bug in curl error handling.

### DIFF
--- a/CRM/Bic/Parser/Parser.php
+++ b/CRM/Bic/Parser/Parser.php
@@ -199,10 +199,14 @@ abstract class CRM_Bic_Parser_Parser {
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
-    $data = curl_exec($ch);
-    curl_close($ch);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 
-    if (!curl_errno($ch)) { 
+    $data = curl_exec($ch);
+
+    $curl_errno = curl_errno($ch);
+    curl_close($ch);
+    
+    if (!$curl_errno) {
        return $data;
     } else {
       return NULL;


### PR DESCRIPTION
Belgian data pull was failing due to lack of support for 301 redirect. Also, checking curl error was happening after closing the curl handle, leading to error messages like "Warning: curl_errno(): 230 is not a valid cURL handle resource in CRM_Bic_Parser_Parser->downloadFile() (line 205 of /path/to/extensions/org.project60.bic/CRM/Bic/Parser/Parser.php)."