### PR TITLE
Replace deprecated curly braces syntax in PHPExcel dependency

### DIFF
--- a/dependencies/PHPExcel/Calculation.php
+++ b/dependencies/PHPExcel/Calculation.php
@@ -2771,10 +2771,10 @@ class PHPExcel_Calculation {
 		//	Loop through the formula extracting each operator and operand in turn
 		while(TRUE) {
 //echo 'Assessing Expression '.substr($formula, $index),PHP_EOL;
-			$opCharacter = $formula{$index};	//	Get the first character of the value at the current index position
+			$opCharacter = $formula[$index];	//	Get the first character of the value at the current index position
 //echo 'Initial character of expression block is '.$opCharacter,PHP_EOL;
-			if ((isset(self::$_comparisonOperators[$opCharacter])) && (strlen($formula) > $index) && (isset(self::$_comparisonOperators[$formula{$index+1}]))) {
-				$opCharacter .= $formula{++$index};
+			if ((isset(self::$_comparisonOperators[$opCharacter])) && (strlen($formula) > $index) && (isset(self::$_comparisonOperators[$formula[$index+1]]))) {
+				$opCharacter .= $formula[++$index];
 //echo 'Initial character of expression block is comparison operator '.$opCharacter.PHP_EOL;
 			}
 
@@ -3049,11 +3049,11 @@ class PHPExcel_Calculation {
 				}
 			}
 			//	Ignore white space
-			while (($formula{$index} == "\n") || ($formula{$index} == "\r")) {
+			while (($formula[$index] == "\n") || ($formula[$index] == "\r")) {
 				++$index;
 			}
-			if ($formula{$index} == ' ') {
-				while ($formula{$index} == ' ') {
+			if ($formula[$index] == ' ') {
+				while ($formula[$index] == ' ') {
 					++$index;
 				}
 				//	If we're expecting an operator, but only have a space between the previous and next operands (and both are

--- a/dependencies/PHPExcel/Reader/Excel5.php
+++ b/dependencies/PHPExcel/Reader/Excel5.php
@@ -2826,7 +2826,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 			$pos += 2;
 
 			// option flags
-			$optionFlags = ord($recordData{$pos});
+			$optionFlags = ord($recordData[$pos]);
 			++$pos;
 
 			// bit: 0; mask: 0x01; 0 = compressed; 1 = uncompressed
@@ -2895,7 +2895,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
 					// repeated option flags
 					// OpenOffice.org documentation 5.21
-					$option = ord($recordData{$pos});
+					$option = ord($recordData[$pos]);
 					++$pos;
 
 					if ($isCompressed && ($option == 0)) {
@@ -2919,7 +2919,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 						// this fragment compressed
 						$len = min($charsLeft, $limitpos - $pos);
 						for ($j = 0; $j < $len; ++$j) {
-							$retstr .= $recordData{$pos + $j} . chr(0);
+							$retstr .= $recordData[$pos + $j] . chr(0);
 						}
 						$charsLeft -= $len;
 						$isCompressed = false;
@@ -4544,9 +4544,9 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 				$hyperlinkType = 'UNC';
 			} else if (!$isFileLinkOrUrl) {
 				$hyperlinkType = 'workbook';
-			} else if (ord($recordData{$offset}) == 0x03) {
+			} else if (ord($recordData[$offset]) == 0x03) {
 				$hyperlinkType = 'local';
-			} else if (ord($recordData{$offset}) == 0xE0) {
+			} else if (ord($recordData[$offset]) == 0xE0) {
 				$hyperlinkType = 'URL';
 			}
 

--- a/dependencies/PHPExcel/Reader/SYLK.php
+++ b/dependencies/PHPExcel/Reader/SYLK.php
@@ -267,7 +267,7 @@ class PHPExcel_Reader_SYLK extends PHPExcel_Reader_Abstract implements PHPExcel_
 									break;
 						case 'S' :	$styleSettings = substr($rowDatum,1);
 									for ($i=0;$i<strlen($styleSettings);++$i) {
-										switch ($styleSettings{$i}) {
+										switch ($styleSettings[$i]) {
 											case 'I' :	$formatArray['font']['italic'] = true;
 														break;
 											case 'D' :	$formatArray['font']['bold'] = true;
@@ -365,7 +365,7 @@ class PHPExcel_Reader_SYLK extends PHPExcel_Reader_Abstract implements PHPExcel_
 									break;
 						case 'S' :	$styleSettings = substr($rowDatum,1);
 									for ($i=0;$i<strlen($styleSettings);++$i) {
-										switch ($styleSettings{$i}) {
+										switch ($styleSettings[$i]) {
 											case 'I' :	$styleData['font']['italic'] = true;
 														break;
 											case 'D' :	$styleData['font']['bold'] = true;

--- a/dependencies/PHPExcel/Shared/OLE.php
+++ b/dependencies/PHPExcel/Shared/OLE.php
@@ -447,7 +447,7 @@ class PHPExcel_Shared_OLE
 	{
 		$rawname = '';
 		for ($i = 0; $i < strlen($ascii); ++$i) {
-			$rawname .= $ascii{$i} . "\x00";
+			$rawname .= $ascii[$i] . "\x00";
 		}
 		return $rawname;
 	}

--- a/dependencies/PHPExcel/Shared/String.php
+++ b/dependencies/PHPExcel/Shared/String.php
@@ -533,8 +533,8 @@ class PHPExcel_Shared_String
 		$len = strlen($str);
 		$newstr = '';
 		for($i=0;$i<$len;$i+=2) {
-			if( $bom_be ) { $val = ord($str{$i})   << 4; $val += ord($str{$i+1}); }
-			else {        $val = ord($str{$i+1}) << 4; $val += ord($str{$i}); }
+			if( $bom_be ) { $val = ord($str[$i])   << 4; $val += ord($str[$i+1]); }
+			else {        $val = ord($str[$i+1]) << 4; $val += ord($str[$i]); }
 			$newstr .= ($val == 0x228) ? "\n" : chr($val);
 		}
 		return $newstr;


### PR DESCRIPTION
Deprecated syntax in PHPExcel dependency causes the parser to fail when processing XLS files on PHP8. 
This quick fix involves replacing the curly braces syntax where necessary for the parser to run without error.