### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/api/v3/Bic.php
+++ b/api/v3/Bic.php
@@ -130,8 +130,8 @@ function civicrm_api3_bic_get($params) {
         'bic'         => $value['name'],
         'country'     => substr($value['value'], 0, 2),
         'nbid'        => substr($value['value'], 2),
-        'description' => CRM_Utils_Array::value('description', $value),
-        'title'       => CRM_Utils_Array::value('label', $value),
+        'description' => $value['description'] ?? NULL,
+        'title'       => $value['label'] ?? NULL,
       ];
     }
   }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.