### PR TITLE
Remove deprecated curl_close

### DIFF
--- a/CRM/Bic/Parser/Parser.php
+++ b/CRM/Bic/Parser/Parser.php
@@ -232,7 +232,6 @@ abstract class CRM_Bic_Parser_Parser {
     $data = curl_exec($ch);
 
     $curl_errno = curl_errno($ch);
-    curl_close($ch);
 
     if (!$curl_errno) {
       return $data;


### PR DESCRIPTION
This function is deprecated as of php 8.0 and does nothing.
See https://www.php.net/manual/en/function.curl-close.php