### PR TITLE
Fix the download of the list of banks from the Netherlands

### DIFF
--- a/CRM/Bic/Parser/NL.php
+++ b/CRM/Bic/Parser/NL.php
@@ -42,7 +42,7 @@ class CRM_Bic_Parser_NL extends CRM_Bic_Parser_Parser {
 
     // Set reader options
     $excel_reader->setReadDataOnly(TRUE);
-    $excel_reader->setLoadSheetsOnly(['BIC-lijst']);
+    $excel_reader->setLoadSheetsOnly(['BIC-lijst | BIC-list']);
 
     // Read Excel file
     $excel_object = $excel_reader->load($file_name);


### PR DESCRIPTION
The betaalvereniging changed the name of the tab with the list of banks from _BIC-lijst_ to _BIC-lijst | BIC-list_ . This fixes this problem.